### PR TITLE
re-export bigdecimal struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,3 +42,5 @@
 pub mod core;
 pub mod examples;
 mod tests;
+
+pub use bigdecimal::BigDecimal;


### PR DESCRIPTION
fixes #40 

Users cannot implement Wrapper::security_definition_option_parameter in their own projects unless they have an identical version of the bigdecimal library in their cargo file.

By re-exporting, the user can match versions easily and implement Wrapper.